### PR TITLE
Fix Base64 encoding for BasicAuth

### DIFF
--- a/lib/WWW/ClickSendClient/ApiClient.pm
+++ b/lib/WWW/ClickSendClient/ApiClient.pm
@@ -344,7 +344,7 @@ sub update_params_for_auth {
         elsif ($auth eq 'BasicAuth') {
             
             if ($self->{config}{username} || $self->{config}{password}) {
-                $header_params->{'Authorization'} = 'Basic ' . encode_base64($self->{config}{username} . ":" . $self->{config}{password});
+                $header_params->{'Authorization'} = 'Basic ' . encode_base64($self->{config}{username} . ":" . $self->{config}{password}, '');
             }
         }
         else {


### PR DESCRIPTION
The ClickSend server doesn't understand BasicAuth when the base64 encoding wraps beyond 1 line such as is the case when you have a longer username + password (API key). To fix this, instruct enclude_base64() to use nothing as the ```$eol``` character rather than the default of newline.